### PR TITLE
http_destination variables should be encoded

### DIFF
--- a/resources/service/message_send_outbound.php
+++ b/resources/service/message_send_outbound.php
@@ -365,11 +365,11 @@
 	}
 
 //exchange variable name with their values
-	$setting['http_destination'] = str_replace("\${from}", $message_from, $setting['http_destination']);
-	$setting['http_destination'] = str_replace("\${message_from}", $message_from, $setting['http_destination']);
-	$setting['http_destination'] = str_replace("\${to}", $message_to, $setting['http_destination']);
-	$setting['http_destination'] = str_replace("\${message_to}", $message_to, $setting['http_destination']);
-	$setting['http_destination'] = str_replace("\${message_text}", $message_text, $setting['http_destination']);
+	$setting['http_destination'] = str_replace("\${from}", urlencode($message_from), $setting['http_destination']);
+	$setting['http_destination'] = str_replace("\${message_from}", urlencode($message_from), $setting['http_destination']);
+	$setting['http_destination'] = str_replace("\${to}", urlencode($message_to), $setting['http_destination']);
+	$setting['http_destination'] = str_replace("\${message_to}", urlencode($message_to), $setting['http_destination']);
+	$setting['http_destination'] = str_replace("\${message_text}", urlencode($message_text), $setting['http_destination']);
 
 //logging info
 	//view_array($setting, false);


### PR DESCRIPTION
This change adds URL encoding to the values put in the http_destination.

This may not have come up before because most providers use POST forms or json to send data back and forth. My provider uses GET messages and the lack of encoding means that any special characters result in a failure