### PR TITLE
updated the sorting order of the conversations view

### DIFF
--- a/messages_contacts.php
+++ b/messages_contacts.php
@@ -140,12 +140,15 @@
 	$sql .= ") as n\n";
 
 	$sql .= "order by \n";
-	$sql .= "case when (number = :number) then 0 end asc,\n";
+	//uncomment below to have the selected message pop up to the top of the list
+	//$sql .= "case when (number = :number) then 0 end asc,\n";
 	$sql .= "date desc\n";
 
 	$parameters['domain_uuid'] = $domain_uuid;
 	$parameters['user_uuid'] = $_SESSION['user']['user_uuid'];
-	$parameters['number'] = $_SESSION['user']['contact_number'] ?? null;
+
+	//uncomment below to have the selected message pop up to the top of the list
+	//$parameters['number'] = $_SESSION['user']['contact_number'] ?? null;
 //echo "<pre>\n";
 //echo $sql;
 //echo "</pre>\n";


### PR DESCRIPTION
The sorting order of conversations has been adjusted so that selected messages are no longer brought to the top.

This is more in line with expected behavior from other chat apps