### PR TITLE
fix for external parties that need to access media

### DIFF
--- a/index.php
+++ b/index.php
@@ -482,7 +482,7 @@ if (count($message_content) == 3) {
 				$array['message_media'][$index]['message_media_date'] = 'now()';
 
 				$array['message_media'][$index]['message_media_url'] = $message_media_url;
-				$array['message_media'][$index]['message_media_content'] = base64_encode(file_get_contents($message_media_url));
+				$array['message_media'][$index]['message_media_content'] = base64_encode(url_get_contents($message_media_url));
 			}
 		}
 	}

--- a/message_media.php
+++ b/message_media.php
@@ -45,9 +45,11 @@
 			$sql .= "and user_uuid = :user_uuid ";
 			$parameters['user_uuid'] = $_SESSION['user_uuid'];
 		}
-		$sql .= "and (domain_uuid = :domain_uuid or domain_uuid is null) ";
+		if (is_uuid($_SESSION['domain_uuid'])) {
+			$sql .= "and (domain_uuid = :domain_uuid or domain_uuid is null) ";
+			$parameters['domain_uuid'] = $_SESSION['domain_uuid'];
+		}
 		$parameters['message_media_uuid'] = $message_media_uuid;
-		$parameters['domain_uuid'] = $_SESSION['domain_uuid'];
 		$database = new database;
 		$media = $database->select($sql, $parameters, 'row');
 		unset($sql, $parameters);


### PR DESCRIPTION
Commit 1: This fix is to allow external parties (like an MMS Provider) that do not have a session, to access media that was sent to them.

Commit 2: Use the new url_get_contents function which uses curl rather than file_get_contents. This was merged [here](https://github.com/fusionpbx/fusionpbx/pull/7073)