### PR TITLE
Move the New Message button to the messages section

### DIFF
--- a/app_languages.php
+++ b/app_languages.php
@@ -49,25 +49,25 @@
 		$text['title-message']['ja-jp'] = 'メッセージ';
 		$text['title-message']['ko-kr'] = '메시지';
 
-		$text['title-message_log']['en-us'] = 'Message Log';
-		$text['title-message_log']['en-gb'] = 'Message Log';
-		$text['title-message_log']['ar-eg'] = 'سجل الرسائل';
-		$text['title-message_log']['de-at'] = 'Nachrichtenprotokoll';
-		$text['title-message_log']['de-ch'] = 'Nachrichtenprotokoll';
-		$text['title-message_log']['de-de'] = 'Nachrichtenprotokoll';
-		$text['title-message_log']['es-cl'] = 'Registro de mensajes';
-		$text['title-message_log']['es-mx'] = 'Registro de mensajes';
-		$text['title-message_log']['fr-ca'] = 'Journal des messages';
-		$text['title-message_log']['fr-fr'] = 'Journal des messages';
+		$text['title-message_log']['en-us'] = 'Message Logs';
+		$text['title-message_log']['en-gb'] = 'Message Logs';
+		$text['title-message_log']['ar-eg'] = 'سجلات الرسائل';
+		$text['title-message_log']['de-at'] = 'Nachrichtenprotokolle';
+		$text['title-message_log']['de-ch'] = 'Nachrichtenprotokolle';
+		$text['title-message_log']['de-de'] = 'Nachrichtenprotokolle';
+		$text['title-message_log']['es-cl'] = 'Registros de mensajes';
+		$text['title-message_log']['es-mx'] = 'Registros de mensajes';
+		$text['title-message_log']['fr-ca'] = 'Journaux des messages';
+		$text['title-message_log']['fr-fr'] = 'Journaux des messages';
 		$text['title-message_log']['he-il'] = 'יומן הודעות';
 		$text['title-message_log']['it-it'] = 'Registro dei messaggi';
-		$text['title-message_log']['nl-nl'] = 'Boodschap log';
+		$text['title-message_log']['nl-nl'] = 'Boodschappen log';
 		$text['title-message_log']['pl-pl'] = 'Dziennik wiadomości';
-		$text['title-message_log']['pt-br'] = 'Log de mensagens';
-		$text['title-message_log']['pt-pt'] = 'Log de mensagens';
+		$text['title-message_log']['pt-br'] = 'Logs de mensagens';
+		$text['title-message_log']['pt-pt'] = 'Logs de mensagens';
 		$text['title-message_log']['ro-ro'] = 'Jurnalul de mesaje';
 		$text['title-message_log']['ru-ru'] = 'Журнал сообщений';
-		$text['title-message_log']['sv-se'] = 'Meddelandelogg';
+		$text['title-message_log']['sv-se'] = 'Meddelandeloggar';
 		$text['title-message_log']['uk-ua'] = 'Журнал повідомлень';
 		$text['title-message_log']['zh-cn'] = '消息日志';
 		$text['title-message_log']['ja-jp'] = 'メッセージログ';
@@ -400,25 +400,25 @@
 		$text['label-new_message']['ja-jp'] = '新しいメッセージ';
 		$text['label-new_message']['ko-kr'] = '새로운 메시지';
 
-		$text['label-log']['en-us'] = 'Log';
-		$text['label-log']['en-gb'] = 'Log';
-		$text['label-log']['ar-eg'] = 'سجل';
-		$text['label-log']['de-at'] = 'Protokoll';
-		$text['label-log']['de-ch'] = 'Protokoll';
-		$text['label-log']['de-de'] = 'Protokoll';
-		$text['label-log']['es-mx'] = 'Registro';
-		$text['label-log']['fr-ca'] = 'Enregistrer';
-		$text['label-log']['fr-fr'] = 'Enregistrer';
-		$text['label-log']['he-il'] = 'עֵץ';
-		$text['label-log']['it-it'] = "Tronco d'albero";
-		$text['label-log']['nl-nl'] = 'Logboek';
-		$text['label-log']['pl-pl'] = 'Dziennik';
-		$text['label-log']['pt-br'] = 'Registro';
-		$text['label-log']['pt-pt'] = 'Registro';
-		$text['label-log']['ro-ro'] = 'Buturuga';
-		$text['label-log']['ru-ru'] = 'Бревно';
-		$text['label-log']['sv-se'] = 'Logga';
-		$text['label-log']['uk-ua'] = 'Журнал';
+		$text['label-log']['en-us'] = 'Logs';
+		$text['label-log']['en-gb'] = 'Logs';
+		$text['label-log']['ar-eg'] = 'سجلات';
+		$text['label-log']['de-at'] = 'Protokolle';
+		$text['label-log']['de-ch'] = 'Protokolle';
+		$text['label-log']['de-de'] = 'Protokolle';
+		$text['label-log']['es-mx'] = 'Registros';
+		$text['label-log']['fr-ca'] = 'Enregistrements';
+		$text['label-log']['fr-fr'] = 'Enregistrements';
+		$text['label-log']['he-il'] = 'עֵצִים';
+		$text['label-log']['it-it'] = 'Tronchi d’albero';
+		$text['label-log']['nl-nl'] = 'Logboeken';
+		$text['label-log']['pl-pl'] = 'Dzienniki';
+		$text['label-log']['pt-br'] = 'Registros';
+		$text['label-log']['pt-pt'] = 'Registros';
+		$text['label-log']['ro-ro'] = 'Buturugi';
+		$text['label-log']['ru-ru'] = 'Бревна';
+		$text['label-log']['sv-se'] = 'Loggar';
+		$text['label-log']['uk-ua'] = 'Журнали';
 		$text['label-log']['zh-cn'] = '日志';
 		$text['label-log']['ja-jp'] = 'ログ';
 		$text['label-log']['ko-kr'] = '통나무';
@@ -1078,7 +1078,7 @@
 		$text['label-message_read']['zh-cn'] = "已读";
 		$text['label-message_read']['ja-jp'] = "読了";
 		$text['label-message_read']['ko-kr'] = "읽음";
-		
+
 		$text['label-message_unread']['en-us'] = "Unread";
 		$text['label-message_unread']['en-gb'] = "Unread";
 		$text['label-message_unread']['ar-eg'] = "غير مقروء";
@@ -1105,7 +1105,7 @@
 		$text['label-message_unread']['zh-cn'] = "未读";
 		$text['label-message_unread']['ja-jp'] = "未読";
 		$text['label-message_unread']['ko-kr'] = "읽지 않음";
-		
+
 		$text['label-message_received']['en-us'] = "Received";
 		$text['label-message_received']['en-gb'] = "Received";
 		$text['label-message_received']['ar-eg'] = "تم الاستلام";
@@ -1132,7 +1132,7 @@
 		$text['label-message_received']['zh-cn'] = "已接收";
 		$text['label-message_received']['ja-jp'] = "受信";
 		$text['label-message_received']['ko-kr'] = "수신됨";
-		
+
 		$text['label-message_sent']['en-us'] = "Sent";
 		$text['label-message_sent']['en-gb'] = "Sent";
 		$text['label-message_sent']['ar-eg'] = "مرسل";
@@ -1159,7 +1159,7 @@
 		$text['label-message_sent']['zh-cn'] = "已发送";
 		$text['label-message_sent']['ja-jp'] = "送信済み";
 		$text['label-message_sent']['ko-kr'] = "보낸";
-		
+
 		$text['label-message_description']['en-us'] = "Description";
 		$text['label-message_description']['en-gb'] = "Description";
 		$text['label-message_description']['ar-eg'] = "الوصف";

--- a/messages.php
+++ b/messages.php
@@ -390,25 +390,35 @@
 	echo "<div class='action_bar' id='action_bar'>\n";
 	echo "	<div class='heading'><b>".$text['title-messages']."</b></div>\n";
 	echo "	<div class='actions'>\n";
-	if (permission_exists('message_add')) {
-		echo button::create(['type'=>'button','label'=>$text['label-new_message'],'icon'=>$_SESSION['theme']['button_icon_add'],'id'=>'btn_add','onclick'=>"document.getElementById('message_new').reset(); $('#message_new_layer').fadeIn(200); unload_thread();"]);
-		//echo button::create(['type'=>'button','label'=>$text['label-new_message'],'icon'=>$_SESSION['theme']['button_icon_add'],'id'=>'btn_add','onclick'=>"document.getElementById('message_new').reset();$('#message_new_layer').fadeIn(200); unload_thread();"]);
-	}
 	if (permission_exists('message_log_view')) {
 		echo button::create(['type'=>'button','label'=>$text['label-log'],'icon'=>'list','link'=>'message_logs.php']);
 	}
 	echo "	</div>\n";
 	echo "	<div style='clear: both;'></div>\n";
 	echo "</div>\n";
-
 	echo "<div class='card'>\n";
 	echo "	<div class='container'>\n";
-	echo "		<div class='contacts'>\n";
-	echo "			<iframe id='contacts_frame' style='width: 100%; height: 100%;' src='messages_contacts.php' frameborder='0'></iframe>\n";
-	echo "		</div>\n";
-	echo "		<div class='messages'>\n";
-	echo "			<iframe id='messages_frame' class='myautoscroll' style='width: 100%; height: 100%;' src='messages_thread.php' frameborder='0'></iframe>\n";
-	echo "		</div>\n";
+	echo "        <div class='contacts'>\n";
+
+	if (permission_exists('message_add')) {
+	    echo "            <div style='padding:10px;'>\n";
+	    echo button::create([
+	        'type'=>'button',
+	        'label'=>$text['label-new_message'],
+	        'icon'=>$_SESSION['theme']['button_icon_add'],
+	        'id'=>'btn_add',
+	        'style'=>'min-width:120px; max-width:120px; margin:0;',
+	        'onclick'=>"document.getElementById('message_new').reset(); $('#message_new_layer').fadeIn(200); unload_thread();"
+	    ]);
+	    echo "            </div>\n";
+	}
+
+	echo "            <iframe id='contacts_frame'
+	                    style='width:100%; height:calc(100% - 60px);'
+	                    src='messages_contacts.php'
+	                    frameborder='0'></iframe>\n";
+
+	echo "        </div>\n";
 
 	if (permission_exists('message_add')) {
 		echo "	<div class='send'>\n";


### PR DESCRIPTION
Before having any messages the current layout creates a little confusion. This pull request moves the New Message button to be in the messages section to be more intuitive.

before:
<img width="1465" height="783" alt="92a23a42-a02c-44a1-83f1-ac5b469afca5" src="https://github.com/user-attachments/assets/19176b16-a7e6-433d-bd17-d189c4bc51b4" />


after pull request:
<img width="1456" height="774" alt="Firefox_Screenshot_2026-06-11T16-53-26 019Z" src="https://github.com/user-attachments/assets/e19208dc-d7fa-48ac-a866-e4b02bc546ea" />

After pull request with existing messages:
<img width="1383" height="770" alt="Firefox_Screenshot_2026-06-11T17-07-16 188Z" src="https://github.com/user-attachments/assets/f1ffd36b-78bf-482f-94c4-aa78cbfce6f1" />

This pull request also changes the singular form of Log and Message Log to the plural form Logs and Message Logs as they are being used for multiple logs.